### PR TITLE
import nécessaire

### DIFF
--- a/agenda/events/views.py
+++ b/agenda/events/views.py
@@ -19,7 +19,7 @@
 #
 
 from datetime import date, timedelta
-from django.shortcuts import HttpResponseRedirect
+from django.shortcuts import render_to_response, HttpResponseRedirect
 from django.core.urlresolvers import reverse
 
 from django.template.response import TemplateResponse


### PR DESCRIPTION
Pour les pages http://agendadulibre.qc.ca/event/stats/ et http://agendadulibre.qc.ca/event/feeds/

Je n'ai pas testé (et je ne connais absolument pas django), il y a peut-être d'autres problèmes liés à l'affichages de ces 2 pages.